### PR TITLE
FIX: g and G for Mac

### DIFF
--- a/content.js
+++ b/content.js
@@ -183,8 +183,24 @@ function goToStartOfWord() {
     sendKeyEvent("left", wordMods())
 }
 
+function goToDocStart(shift = false) {
+    if (isMac) {
+        sendKeyEvent("up", { meta: true, shift })
+    } else {
+        sendKeyEvent("home", { control: true, shift })
+    }
+}
+
+function goToDocEnd(shift = false) {
+    if (isMac) {
+        sendKeyEvent("down", { meta: true, shift })
+    } else {
+        sendKeyEvent("end", { control: true, shift })
+    }
+}
+
 function goToTop() {
-    sendKeyEvent("home", { control: true, shift: true })
+    goToDocStart(true)
     longStringOp = ""
 }
 
@@ -413,10 +429,10 @@ function handleKeyEventNormal(key) {
             goToEndOfWord()
             break
         case "g":
-            sendKeyEvent("home", { control: true })
+            goToDocStart()
             break
         case "G":
-            sendKeyEvent("end", { control: true })
+            goToDocEnd()
             break
         case "c":
         case "d":
@@ -536,10 +552,10 @@ function handleKeyEventVisualLine(key) {
             selectToEndOfLine()
             break
         case "G":
-            sendKeyEvent("end", { control: true, shift: true })
+            goToDocEnd(true)
             break
         case "g":
-            sendKeyEvent("home", { control: true, shift: true })
+            goToDocStart(true)
             break
         case "c":
         case "d":


### PR DESCRIPTION
**Problem:**
Expected: `g` and `G` navigation to move cursor to top and bottom of doc 
Actual: no movement
Device: macOS Tahoe 26.4.1

**Solution:**
Added send Command+Up and Command+Down keys for Mac-specific