### PR TITLE
FIX: use correct iframe selector and defer init until Docs is ready

### DIFF
--- a/content.js
+++ b/content.js
@@ -9,10 +9,7 @@
 // before sending to layout engine and interpret them into respective vim motion/command.
 // Then implement those motions by sending relevant keystrokes. Essentially doing a keystroke to keystroke remapping. 
 
-const iframe = document.getElementsByTagName('iframe')[0]   // https://stackoverflow.com/a/4388829
-iframe.contentDocument.addEventListener('keydown', eventHandler, true)
-
-const cursorTop = document.getElementsByClassName("kix-cursor-top")[0] // element to edit to show normal vs insert mode
+let cursorTop = null
 let mode = 'normal'
 let tempnormal = false // State variable for indicating temperory normal mode
 let multipleMotion = {
@@ -124,16 +121,19 @@ function switchModeToNormal() {
     mode = 'normal'
     updateModeIndicator(mode)
 
-    //caret indicating visual mode 
-    cursorTop.style.opacity = 1
-    cursorTop.style.display = "block"
-    cursorTop.style.backgroundColor = "black"
+    cursorTop = cursorTop || document.getElementsByClassName("kix-cursor-top")[0]
+    if (cursorTop) {
+        cursorTop.style.opacity = 1
+        cursorTop.style.display = "block"
+        cursorTop.style.backgroundColor = "black"
+    }
 }
 
 function switchModeToInsert() {
     mode = 'insert'
     updateModeIndicator(mode)
-    cursorTop.style.opacity = 0
+    cursorTop = cursorTop || document.getElementsByClassName("kix-cursor-top")[0]
+    if (cursorTop) cursorTop.style.opacity = 0
 }
 
 function switchModeToWait() {
@@ -685,5 +685,17 @@ function activateTopLevelMenu(menuCaption) {
     simulateClick(button);
 }
 
-// Initiate to Normal Mode
-switchModeToNormal()
+function initialize() {
+    const iframe = document.querySelector('.docs-texteventtarget-iframe')
+    if (!iframe || !iframe.contentDocument) return false
+    iframe.contentDocument.addEventListener('keydown', eventHandler, true)
+    switchModeToNormal()
+    return true
+}
+
+if (!initialize()) {
+    const observer = new MutationObserver(() => {
+        if (initialize()) observer.disconnect()
+    })
+    observer.observe(document.documentElement, { childList: true, subtree: true })
+}


### PR DESCRIPTION
## Problem

The extension shows the NORMAL mode indicator but keystrokes are not intercepted — text inserts as if in insert mode.

Two bugs cause this:

1. **Wrong iframe**: `content.js` used `getElementsByTagName('iframe')[0]`, which returns the first iframe in DOM order. Google Docs has multiple iframes; the text event target is `.docs-texteventtarget-iframe`. The keydown listener was attached to the wrong element, so keystrokes were never intercepted. (`page_script.js` already used the correct selector — this brings `content.js` in line with it.)

2. **Timing race**: Google Docs injects its iframes dynamically after `document_idle`. Even with the correct selector, the element may not exist when the content script runs. A `MutationObserver` now defers initialization until the target iframe appears. `cursorTop` (`.kix-cursor-top`) is fetched lazily for the same reason.

## Changes

- Replace `getElementsByTagName('iframe')[0]` with `document.querySelector('.docs-texteventtarget-iframe')`
- Wrap initialization in a function; if the element isn't present yet, a `MutationObserver` retries until it is
- Fetch `cursorTop` lazily in `switchModeToNormal` / `switchModeToInsert` with a null guard

## Test plan

- [ ] Load a Google Doc — NORMAL mode indicator appears and vim motions work immediately
- [ ] Hard-refresh the doc — extension still initializes correctly
- [ ] Press `i` to enter insert mode, type text, press `Escape` — returns to NORMAL and keystrokes are intercepted again